### PR TITLE
support for multiple tables

### DIFF
--- a/tools/osgende-mapgen
+++ b/tools/osgende-mapgen
@@ -651,7 +651,7 @@ if __name__ == '__main__':
         exit(-1)
 
     if options.changetable is None:
-        print 'Warning: no change table supplied. This wil lead to every tile'
+        print 'Warning: no change table supplied. This will lead to every tile'
         print '         being considered changed and therefore processed, which'
         print '         probably is not what you intended.'
         if options.datatable is not None:


### PR DESCRIPTION
Add support for multiple, comma separated tables to the osgende-mapgen tool
Add a warning to the osgende-mapgen tool if no change table was supplied
