### PR TITLE
reverse first segment after a gap

### DIFF
--- a/test/features/routetable.feature
+++ b/test/features/routetable.feature
@@ -28,6 +28,25 @@ Feature: Route table from RouteSegments
         | 2  | bar  | 4, 5, 6 |
         | 3  | bazz | (7, 8), (12, 11, 10, 9)  |
 
+    Scenario: non-continuous route
+      Given a 0.001 node grid
+        | 1 | 2 | 3 | 4 |
+        |   | 5 |   | 6 |
+        |   | 7 | 8 |   |
+      And the osm data
+        | id | data       | tags |
+        | W1 | 1,2        | |
+        | W2 | 2,3,4      | |
+        | W3 | 2,5        | |
+        | W4 | 5,7,8      | |
+        | W5 | 6,4        | |
+        | R1 | W1,W2,W5,W3,W4  | HIKING |
+      When constructing a RouteSegments table 'Hiking'
+      And constructing a Routes table 'HikingRoutes' from 'Hiking'
+      Then table HikingRoutes consists of
+        | id | name | geom |
+        | 1  | x  | (1, 2, 3, 4, 6), (2, 5, 7, 8) |
+
     Scenario: Route with roundabout
       Given a 0.001 node grid
         |   |   | 3 |   |   |


### PR DESCRIPTION
When the first LineString after a gap in the relation gets added,
we have to check if it has to be reversed as if it were the first segment
of the route.

The attached test fails on my machine (I don't know, what order the geometry has or if it has defined an ordering in general?)

```cucumber
Scenario: non-continuous route
  Given the following tag sets
    | name   | tags                                               |
    | HIKING | 'type' : 'route', 'route' : 'hiking', 'name' : 'x' |
  Given a 0.001 node grid
    | 1 | 2 | 3 | 4 |
    |   | 5 |   | 6 |
    |   | 7 | 8 |   |
  And the osm data
    | id | data           | tags   |
    | W1 | 1,2            |        |
    | W2 | 2,3,4          |        |
    | W3 | 2,5            |        |
    | W4 | 5,7,8          |        |
    | W5 | 6,4            |        |
    | R1 | W1,W2,W5,W3,W4 | HIKING |
  When constructing a RouteSegments table 'Hiking'
  And constructing a Routes table 'HikingRoutes' from 'Hiking'
  Then table HikingRoutes consists of
    | id | name | geom                          |
    | 1  | x    | (1, 2, 3, 4, 6), (2, 5, 7, 8) |
    Assertion Failed: ('1', 'x', '(0.0 0.0, 0.001 0.0, 0.002 0.0, 0.003 0.0, 0.003 0.001), (0.001 0.001, 0.001 0.0), (0.001 0.001, 0.001 0.002, 0.002 0.002)')
        not found in {('1', 'x', '(0.0 0.0, 0.001 0.0, 0.002 0.0, 0.003 0.0, 0.003 0.001), (0.001 0.0, 0.001 0.001, 0.001 0.002, 0.002 0.002)')}
```